### PR TITLE
Add authentication, auditing, and web admin panel to license tools

### DIFF
--- a/license-manager/LicenseManager.Core/Models/AuditEntry.cs
+++ b/license-manager/LicenseManager.Core/Models/AuditEntry.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace LicenseManager.Models;
+
+public class AuditEntry
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public DateTime Timestamp { get; set; } = DateTime.UtcNow;
+
+    public string Action { get; set; } = string.Empty;
+
+    public string PerformedBy { get; set; } = string.Empty;
+
+    public Guid? LicenseId { get; set; }
+        = null;
+
+    public string? LicenseKey { get; set; }
+        = null;
+
+    public string? Details { get; set; }
+        = null;
+}

--- a/license-manager/LicenseManager.Core/Models/User.cs
+++ b/license-manager/LicenseManager.Core/Models/User.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace LicenseManager.Models;
+
+public class User
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    public string Username { get; set; } = string.Empty;
+
+    public string PasswordHash { get; set; } = string.Empty;
+
+    public List<string> Roles { get; set; } = new();
+}

--- a/license-manager/LicenseManager.Core/Services/AuditService.cs
+++ b/license-manager/LicenseManager.Core/Services/AuditService.cs
@@ -1,0 +1,79 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using LicenseManager.Models;
+
+namespace LicenseManager.Services;
+
+public class AuditService
+{
+    private readonly string _auditPath;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly object _syncRoot = new();
+
+    public AuditService(string? auditPath = null)
+    {
+        _auditPath = auditPath ?? Path.Combine(AppContext.BaseDirectory, "audit.log");
+    }
+
+    public void Record(string action, string performedBy, License? license = null, string? details = null)
+    {
+        var entry = new AuditEntry
+        {
+            Action = action,
+            PerformedBy = performedBy,
+            LicenseId = license?.Id,
+            LicenseKey = license?.Key,
+            Details = details,
+            Timestamp = DateTime.UtcNow
+        };
+
+        lock (_syncRoot)
+        {
+            var entries = LoadEntriesInternal();
+            entries.Add(entry);
+            SaveEntries(entries);
+        }
+    }
+
+    public IReadOnlyList<AuditEntry> GetEntries(int limit = 100)
+    {
+        lock (_syncRoot)
+        {
+            var entries = LoadEntriesInternal()
+                .OrderByDescending(e => e.Timestamp)
+                .Take(Math.Max(1, limit))
+                .ToList();
+            return entries;
+        }
+    }
+
+    private List<AuditEntry> LoadEntriesInternal()
+    {
+        if (!File.Exists(_auditPath))
+        {
+            return new List<AuditEntry>();
+        }
+
+        using var stream = File.OpenRead(_auditPath);
+        return JsonSerializer.Deserialize<List<AuditEntry>>(stream, _jsonOptions) ?? new List<AuditEntry>();
+    }
+
+    private void SaveEntries(IEnumerable<AuditEntry> entries)
+    {
+        var directory = Path.GetDirectoryName(_auditPath);
+        if (!string.IsNullOrEmpty(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using var stream = File.Create(_auditPath);
+        JsonSerializer.Serialize(stream, entries, _jsonOptions);
+    }
+}

--- a/license-manager/LicenseManager.Core/Services/AuthService.cs
+++ b/license-manager/LicenseManager.Core/Services/AuthService.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using LicenseManager.Models;
+
+namespace LicenseManager.Services;
+
+public class AuthService
+{
+    private readonly string _usersPath;
+    private readonly JsonSerializerOptions _jsonOptions = new()
+    {
+        WriteIndented = true
+    };
+
+    private readonly object _syncRoot = new();
+
+    public AuthService(string? usersPath = null)
+    {
+        _usersPath = usersPath ?? Path.Combine(AppContext.BaseDirectory, "users.json");
+        EnsureSeedUser();
+    }
+
+    public User? Authenticate(string username, string password)
+    {
+        if (string.IsNullOrWhiteSpace(username) || string.IsNullOrEmpty(password))
+        {
+            return null;
+        }
+
+        var users = LoadUsers();
+        var user = users.FirstOrDefault(u =>
+            string.Equals(u.Username, username, StringComparison.OrdinalIgnoreCase));
+
+        if (user is null)
+        {
+            return null;
+        }
+
+        return VerifyPassword(password, user.PasswordHash) ? user : null;
+    }
+
+    public IReadOnlyList<User> LoadUsers()
+    {
+        lock (_syncRoot)
+        {
+            if (!File.Exists(_usersPath))
+            {
+                return Array.Empty<User>();
+            }
+
+            using var stream = File.OpenRead(_usersPath);
+            return JsonSerializer.Deserialize<List<User>>(stream, _jsonOptions) ?? new List<User>();
+        }
+    }
+
+    public void SaveUsers(IEnumerable<User> users)
+    {
+        lock (_syncRoot)
+        {
+            var directory = Path.GetDirectoryName(_usersPath);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                Directory.CreateDirectory(directory);
+            }
+
+            using var stream = File.Create(_usersPath);
+            JsonSerializer.Serialize(stream, users, _jsonOptions);
+        }
+    }
+
+    public static string HashPassword(string password)
+    {
+        using var sha256 = SHA256.Create();
+        var bytes = sha256.ComputeHash(Encoding.UTF8.GetBytes(password));
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+        {
+            builder.AppendFormat("{0:x2}", b);
+        }
+
+        return builder.ToString();
+    }
+
+    private static bool VerifyPassword(string password, string storedHash)
+    {
+        var hashed = HashPassword(password);
+        return string.Equals(hashed, storedHash, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private void EnsureSeedUser()
+    {
+        lock (_syncRoot)
+        {
+            if (File.Exists(_usersPath))
+            {
+                return;
+            }
+
+            var defaultUser = new User
+            {
+                Username = "admin",
+                PasswordHash = HashPassword("admin"),
+                Roles = new List<string> { "Administrator" }
+            };
+
+            SaveUsers(new[] { defaultUser });
+        }
+    }
+}

--- a/license-manager/LicenseManager/LicenseManager.csproj
+++ b/license-manager/LicenseManager/LicenseManager.csproj
@@ -13,5 +13,8 @@
     <None Include="licenses.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="users.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>

--- a/license-manager/LicenseManager/LoginForm.Designer.cs
+++ b/license-manager/LicenseManager/LoginForm.Designer.cs
@@ -1,0 +1,129 @@
+using System.Windows.Forms;
+
+namespace LicenseManager;
+
+partial class LoginForm
+{
+    private Label titleLabel;
+    private Label usernameLabel;
+    private TextBox usernameTextBox;
+    private Label passwordLabel;
+    private TextBox passwordTextBox;
+    private Button loginButton;
+    private Button cancelButton;
+    private Label infoLabel;
+
+    private void InitializeComponent()
+    {
+        titleLabel = new Label();
+        usernameLabel = new Label();
+        usernameTextBox = new TextBox();
+        passwordLabel = new Label();
+        passwordTextBox = new TextBox();
+        loginButton = new Button();
+        cancelButton = new Button();
+        infoLabel = new Label();
+        SuspendLayout();
+        // 
+        // titleLabel
+        // 
+        titleLabel.AutoSize = true;
+        titleLabel.Font = new System.Drawing.Font("Segoe UI", 12F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+        titleLabel.Location = new System.Drawing.Point(24, 20);
+        titleLabel.Name = "titleLabel";
+        titleLabel.Size = new System.Drawing.Size(239, 21);
+        titleLabel.TabIndex = 0;
+        titleLabel.Text = "Entre para acessar o gerenciador";
+        // 
+        // usernameLabel
+        // 
+        usernameLabel.AutoSize = true;
+        usernameLabel.Location = new System.Drawing.Point(24, 60);
+        usernameLabel.Name = "usernameLabel";
+        usernameLabel.Size = new System.Drawing.Size(57, 15);
+        usernameLabel.TabIndex = 1;
+        usernameLabel.Text = "Usuário";
+        // 
+        // usernameTextBox
+        // 
+        usernameTextBox.Location = new System.Drawing.Point(24, 78);
+        usernameTextBox.Name = "usernameTextBox";
+        usernameTextBox.PlaceholderText = "admin";
+        usernameTextBox.Size = new System.Drawing.Size(304, 23);
+        usernameTextBox.TabIndex = 2;
+        // 
+        // passwordLabel
+        // 
+        passwordLabel.AutoSize = true;
+        passwordLabel.Location = new System.Drawing.Point(24, 112);
+        passwordLabel.Name = "passwordLabel";
+        passwordLabel.Size = new System.Drawing.Size(39, 15);
+        passwordLabel.TabIndex = 3;
+        passwordLabel.Text = "Senha";
+        // 
+        // passwordTextBox
+        // 
+        passwordTextBox.Location = new System.Drawing.Point(24, 130);
+        passwordTextBox.Name = "passwordTextBox";
+        passwordTextBox.PlaceholderText = "admin";
+        passwordTextBox.Size = new System.Drawing.Size(304, 23);
+        passwordTextBox.TabIndex = 4;
+        passwordTextBox.UseSystemPasswordChar = true;
+        // 
+        // loginButton
+        // 
+        loginButton.Location = new System.Drawing.Point(164, 174);
+        loginButton.Name = "loginButton";
+        loginButton.Size = new System.Drawing.Size(75, 27);
+        loginButton.TabIndex = 5;
+        loginButton.Text = "Entrar";
+        loginButton.UseVisualStyleBackColor = true;
+        loginButton.Click += OnLogin;
+        // 
+        // cancelButton
+        // 
+        cancelButton.DialogResult = DialogResult.Cancel;
+        cancelButton.Location = new System.Drawing.Point(253, 174);
+        cancelButton.Name = "cancelButton";
+        cancelButton.Size = new System.Drawing.Size(75, 27);
+        cancelButton.TabIndex = 6;
+        cancelButton.Text = "Cancelar";
+        cancelButton.UseVisualStyleBackColor = true;
+        cancelButton.Click += OnCancel;
+        // 
+        // infoLabel
+        // 
+        infoLabel.AutoSize = true;
+        infoLabel.Font = new System.Drawing.Font("Segoe UI", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
+        infoLabel.ForeColor = System.Drawing.SystemColors.GrayText;
+        infoLabel.Location = new System.Drawing.Point(24, 206);
+        infoLabel.Name = "infoLabel";
+        infoLabel.Size = new System.Drawing.Size(245, 13);
+        infoLabel.TabIndex = 7;
+        infoLabel.Text = "Credenciais padrão: admin / admin (altere depois).";
+        // 
+        // LoginForm
+        // 
+        AcceptButton = loginButton;
+        AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+        AutoScaleMode = AutoScaleMode.Font;
+        CancelButton = cancelButton;
+        ClientSize = new System.Drawing.Size(352, 238);
+        Controls.Add(infoLabel);
+        Controls.Add(cancelButton);
+        Controls.Add(loginButton);
+        Controls.Add(passwordTextBox);
+        Controls.Add(passwordLabel);
+        Controls.Add(usernameTextBox);
+        Controls.Add(usernameLabel);
+        Controls.Add(titleLabel);
+        FormBorderStyle = FormBorderStyle.FixedDialog;
+        MaximizeBox = false;
+        MinimizeBox = false;
+        Name = "LoginForm";
+        StartPosition = FormStartPosition.CenterScreen;
+        Text = "Autenticação";
+        ResumeLayout(false);
+        PerformLayout();
+    }
+}

--- a/license-manager/LicenseManager/LoginForm.cs
+++ b/license-manager/LicenseManager/LoginForm.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Windows.Forms;
+using LicenseManager.Models;
+using LicenseManager.Services;
+
+namespace LicenseManager;
+
+public partial class LoginForm : Form
+{
+    private readonly AuthService _authService;
+
+    public User? AuthenticatedUser { get; private set; }
+
+    public LoginForm(AuthService authService)
+    {
+        _authService = authService;
+        InitializeComponent();
+    }
+
+    private void OnLogin(object sender, EventArgs e)
+    {
+        var username = usernameTextBox.Text.Trim();
+        var password = passwordTextBox.Text;
+
+        var user = _authService.Authenticate(username, password);
+        if (user is null)
+        {
+            MessageBox.Show("Credenciais inválidas. Verifique usuário e senha.",
+                "Falha na autenticação", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            passwordTextBox.SelectAll();
+            passwordTextBox.Focus();
+            return;
+        }
+
+        AuthenticatedUser = user;
+        DialogResult = DialogResult.OK;
+        Close();
+    }
+
+    private void OnCancel(object sender, EventArgs e)
+    {
+        DialogResult = DialogResult.Cancel;
+        Close();
+    }
+}

--- a/license-manager/LicenseManager/MainForm.Designer.cs
+++ b/license-manager/LicenseManager/MainForm.Designer.cs
@@ -25,6 +25,7 @@ partial class MainForm
     private DataGridView licensesDataGridView;
     private StatusStrip statusStrip;
     private ToolStripStatusLabel statusStripLabel;
+    private ToolStripStatusLabel userStatusLabel;
     private BindingSource licensesBindingSource;
     private DataGridViewTextBoxColumn keyColumn;
     private DataGridViewTextBoxColumn emailColumn;
@@ -62,6 +63,7 @@ partial class MainForm
         notesColumn = new DataGridViewTextBoxColumn();
         statusStrip = new StatusStrip();
         statusStripLabel = new ToolStripStatusLabel();
+        userStatusLabel = new ToolStripStatusLabel();
         layoutPanel.SuspendLayout();
         toolStrip.SuspendLayout();
         ((ISupportInitialize)licensesDataGridView).BeginInit();
@@ -255,7 +257,7 @@ partial class MainForm
         //
         // statusStrip
         //
-        statusStrip.Items.AddRange(new ToolStripItem[] { statusStripLabel });
+        statusStrip.Items.AddRange(new ToolStripItem[] { statusStripLabel, userStatusLabel });
         statusStrip.Location = new System.Drawing.Point(0, 560);
         statusStrip.Name = "statusStrip";
         statusStrip.Size = new System.Drawing.Size(960, 22);
@@ -264,7 +266,13 @@ partial class MainForm
         //
         // statusStripLabel
         //
+        statusStripLabel.Spring = true;
         statusStripLabel.Text = "Ativas: 0   Inativas: 0   Banidas: 0";
+        statusStripLabel.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+        //
+        // userStatusLabel
+        //
+        userStatusLabel.Text = "Usuário:";
         //
         // MainForm
         //

--- a/license-manager/LicenseManager/users.json
+++ b/license-manager/LicenseManager/users.json
@@ -1,0 +1,8 @@
+[
+  {
+    "Id": "00000000-0000-0000-0000-000000000001",
+    "Username": "admin",
+    "PasswordHash": "8c6976e5b5410415bde908bd4dee15dfb167a9c873fc4bb8a81f6f2ab448a918",
+    "Roles": ["Administrator"]
+  }
+]

--- a/license-manager/LicenseServer/LicenseServerOptions.cs
+++ b/license-manager/LicenseServer/LicenseServerOptions.cs
@@ -13,4 +13,8 @@ public class LicenseServerOptions
     public string ApiVersion { get; set; } = "1";
 
     public string CmsVersion { get; set; } = "2.0.7";
+
+    public string? UserStorePath { get; set; } = "../LicenseManager/users.json";
+
+    public string? AuditPath { get; set; } = "../LicenseManager/audit.log";
 }

--- a/license-manager/LicenseServer/Models/LicenseInput.cs
+++ b/license-manager/LicenseServer/Models/LicenseInput.cs
@@ -1,0 +1,21 @@
+using System;
+using LicenseManager.Models;
+
+namespace LicenseServer.Models;
+
+public class LicenseInput
+{
+    public string Key { get; set; } = string.Empty;
+
+    public string Email { get; set; } = string.Empty;
+
+    public LicenseType Type { get; set; } = LicenseType.Premium;
+
+    public LicenseStatus Status { get; set; } = LicenseStatus.Active;
+
+    public DateTime? ExpiresAt { get; set; }
+        = null;
+
+    public string? Notes { get; set; }
+        = string.Empty;
+}

--- a/license-manager/LicenseServer/Models/LoginRequest.cs
+++ b/license-manager/LicenseServer/Models/LoginRequest.cs
@@ -1,0 +1,8 @@
+namespace LicenseServer.Models;
+
+public class LoginRequest
+{
+    public string Username { get; set; } = string.Empty;
+
+    public string Password { get; set; } = string.Empty;
+}

--- a/license-manager/LicenseServer/Models/StatusUpdateRequest.cs
+++ b/license-manager/LicenseServer/Models/StatusUpdateRequest.cs
@@ -1,0 +1,9 @@
+using LicenseManager.Models;
+
+namespace LicenseServer.Models;
+
+public class StatusUpdateRequest
+{
+    public LicenseStatus Status { get; set; }
+        = LicenseStatus.Active;
+}

--- a/license-manager/LicenseServer/SessionManager.cs
+++ b/license-manager/LicenseServer/SessionManager.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using LicenseManager.Models;
+
+namespace LicenseServer;
+
+public class SessionManager
+{
+    private readonly ConcurrentDictionary<string, SessionInfo> _sessions = new();
+    private readonly TimeSpan _lifetime = TimeSpan.FromHours(8);
+
+    public string CreateSession(User user)
+    {
+        CleanupExpired();
+        var tokenBytes = RandomNumberGenerator.GetBytes(32);
+        var token = Convert.ToHexString(tokenBytes);
+        var session = new SessionInfo(user, DateTime.UtcNow.Add(_lifetime));
+        _sessions[token] = session;
+        return token;
+    }
+
+    public SessionInfo? Validate(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return null;
+        }
+
+        CleanupExpired();
+        if (_sessions.TryGetValue(token, out var session) && session.ExpiresAt > DateTime.UtcNow)
+        {
+            return session;
+        }
+
+        _sessions.TryRemove(token, out _);
+        return null;
+    }
+
+    public void Invalidate(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return;
+        }
+
+        _sessions.TryRemove(token, out _);
+    }
+
+    private void CleanupExpired()
+    {
+        foreach (var entry in _sessions)
+        {
+            if (entry.Value.ExpiresAt <= DateTime.UtcNow)
+            {
+                _sessions.TryRemove(entry.Key, out _);
+            }
+        }
+    }
+}
+
+public record SessionInfo(User User, DateTime ExpiresAt);

--- a/license-manager/LicenseServer/appsettings.json
+++ b/license-manager/LicenseServer/appsettings.json
@@ -2,6 +2,8 @@
   "LicenseServer": {
     "DataPath": "../LicenseManager/licenses.json",
     "ApiVersion": "1",
-    "CmsVersion": "2.0.7"
+    "CmsVersion": "2.0.7",
+    "UserStorePath": "../LicenseManager/users.json",
+    "AuditPath": "../LicenseManager/audit.log"
   }
 }

--- a/license-manager/LicenseServer/wwwroot/admin/app.js
+++ b/license-manager/LicenseServer/wwwroot/admin/app.js
@@ -1,0 +1,402 @@
+(() => {
+  const licenseTypes = ["Lite", "Bronze", "Silver", "Gold", "Premium", "PremiumPlus"];
+  const licenseStatuses = ["Active", "Inactive", "Banned"];
+  let authToken = localStorage.getItem("imperia-license-token") ?? "";
+  let currentLicenses = [];
+
+  const statusMessage = document.getElementById("status-message");
+  const loginSection = document.getElementById("login-section");
+  const dashboardSection = document.getElementById("dashboard-section");
+  const logoutButton = document.getElementById("logout-button");
+  const loginForm = document.getElementById("login-form");
+  const licenseForm = document.getElementById("license-form");
+  const licenseIdInput = document.getElementById("license-id");
+  const licenseKeyInput = document.getElementById("license-key");
+  const licenseEmailInput = document.getElementById("license-email");
+  const licenseTypeSelect = document.getElementById("license-type");
+  const licenseStatusSelect = document.getElementById("license-status");
+  const licenseExpiresInput = document.getElementById("license-expires");
+  const expirationEnabledCheckbox = document.getElementById("license-expiration-enabled");
+  const licenseNotesInput = document.getElementById("license-notes");
+  const licensesBody = document.getElementById("licenses-body");
+  const refreshButton = document.getElementById("refresh-button");
+  const resetButton = document.getElementById("reset-button");
+  const refreshAuditButton = document.getElementById("refresh-audit");
+  const auditList = document.getElementById("audit-list");
+  const formTitle = document.getElementById("form-title");
+  const saveButton = document.getElementById("save-button");
+
+  function showMessage(message, type = "info") {
+    statusMessage.textContent = message;
+    statusMessage.style.color = type === "error" ? "#fecaca" : "#e2e8f0";
+  }
+
+  function toggleDashboard(visible) {
+    if (visible) {
+      loginSection.classList.add("hidden");
+      dashboardSection.classList.remove("hidden");
+      logoutButton.classList.remove("hidden");
+    } else {
+      loginSection.classList.remove("hidden");
+      dashboardSection.classList.add("hidden");
+      logoutButton.classList.add("hidden");
+    }
+  }
+
+  async function apiFetch(url, options = {}) {
+    const opts = { ...options };
+    opts.headers = opts.headers ? { ...opts.headers } : {};
+    if (authToken) {
+      opts.headers["X-Auth-Token"] = authToken;
+    }
+
+    const response = await fetch(url, opts);
+    if (response.status === 401) {
+      handleUnauthorized();
+      let message = "Autenticação obrigatória.";
+      try {
+        const payload = await response.json();
+        if (payload?.message) {
+          message = payload.message;
+        }
+      } catch (error) {
+        // ignore json parse failures
+      }
+      throw new Error(message);
+    }
+
+    if (!response.ok) {
+      let message = "Não foi possível concluir a operação.";
+      try {
+        const payload = await response.json();
+        if (payload?.message) {
+          message = payload.message;
+        }
+      } catch (error) {
+        // ignore json parse failures
+      }
+      throw new Error(message);
+    }
+
+    if (response.status === 204) {
+      return null;
+    }
+
+    const text = await response.text();
+    return text ? JSON.parse(text) : null;
+  }
+
+  function handleUnauthorized() {
+    authToken = "";
+    localStorage.removeItem("imperia-license-token");
+    toggleDashboard(false);
+    showMessage("Sessão expirada. Faça login novamente.", "error");
+  }
+
+  async function login(event) {
+    event.preventDefault();
+    const formData = new FormData(loginForm);
+    try {
+      const result = await apiFetch("/admin/api/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: formData.get("username"),
+          password: formData.get("password")
+        })
+      });
+
+      authToken = result.token;
+      localStorage.setItem("imperia-license-token", authToken);
+      toggleDashboard(true);
+      showMessage(`Bem-vindo, ${result.username}!`);
+      loginForm.reset();
+      await refreshData();
+    } catch (error) {
+      showMessage(error.message, "error");
+    }
+  }
+
+  async function logout() {
+    try {
+      await apiFetch("/admin/api/logout", { method: "POST" });
+    } catch (error) {
+      console.warn(error);
+    } finally {
+      authToken = "";
+      localStorage.removeItem("imperia-license-token");
+      toggleDashboard(false);
+      showMessage("Sessão encerrada com sucesso.");
+    }
+  }
+
+  function resetLicenseForm() {
+    licenseForm.reset();
+    licenseIdInput.value = "";
+    formTitle.textContent = "Cadastrar licença";
+    saveButton.textContent = "Salvar";
+    expirationEnabledCheckbox.checked = true;
+    licenseExpiresInput.disabled = false;
+    const defaultDate = new Date();
+    defaultDate.setMonth(defaultDate.getMonth() + 1);
+    licenseExpiresInput.value = defaultDate.toISOString().slice(0, 16);
+    licenseNotesInput.value = "";
+    licenseStatusSelect.value = "Active";
+    licenseTypeSelect.value = "Premium";
+  }
+
+  function populateSelectOptions() {
+    licenseStatusSelect.innerHTML = "";
+    licenseStatuses.forEach(status => {
+      const option = document.createElement("option");
+      option.value = status;
+      option.textContent = status;
+      licenseStatusSelect.appendChild(option);
+    });
+
+    licenseTypeSelect.innerHTML = "";
+    licenseTypes.forEach(type => {
+      const option = document.createElement("option");
+      option.value = type;
+      option.textContent = type;
+      licenseTypeSelect.appendChild(option);
+    });
+
+    licenseStatusSelect.value = "Active";
+    licenseTypeSelect.value = "Premium";
+  }
+
+  function fillForm(license) {
+    licenseIdInput.value = license.id;
+    licenseKeyInput.value = license.key;
+    licenseEmailInput.value = license.email;
+    licenseTypeSelect.value = license.type;
+    licenseStatusSelect.value = license.status;
+
+    if (license.expiresAt) {
+      const expires = new Date(license.expiresAt);
+      const localValue = new Date(expires.getTime() - expires.getTimezoneOffset() * 60000)
+        .toISOString()
+        .slice(0, 16);
+      licenseExpiresInput.value = localValue;
+      expirationEnabledCheckbox.checked = true;
+      licenseExpiresInput.disabled = false;
+    } else {
+      expirationEnabledCheckbox.checked = false;
+      licenseExpiresInput.disabled = true;
+      licenseExpiresInput.value = "";
+    }
+
+    licenseNotesInput.value = license.notes ?? "";
+    formTitle.textContent = `Editar licença ${license.key}`;
+    saveButton.textContent = "Atualizar";
+  }
+
+  function renderLicenses(licenses) {
+    licensesBody.innerHTML = "";
+    licenses.forEach(license => {
+      const tr = document.createElement("tr");
+      tr.innerHTML = `
+        <td>${escapeHtml(license.key)}</td>
+        <td>${escapeHtml(license.email)}</td>
+        <td>${escapeHtml(license.type)}</td>
+        <td><span class="badge ${license.status}">${license.status}</span></td>
+        <td>${formatDate(license.createdAt)}</td>
+        <td>${license.expiresAt ? formatDate(license.expiresAt) : "&mdash;"}</td>
+        <td>${license.notes ? escapeHtml(license.notes) : "&mdash;"}</td>
+        <td>
+          <div class="actions" data-id="${license.id}">
+            <button data-action="edit">Editar</button>
+            <button data-action="activate">Ativar</button>
+            <button data-action="deactivate">Inativar</button>
+            <button data-action="ban">Banir</button>
+            <button data-action="delete" class="danger">Excluir</button>
+          </div>
+        </td>`;
+      licensesBody.appendChild(tr);
+    });
+  }
+
+  function renderAudit(entries) {
+    auditList.innerHTML = "";
+    if (!entries.length) {
+      const empty = document.createElement("li");
+      empty.textContent = "Nenhum evento recente.";
+      empty.style.color = "var(--muted)";
+      auditList.appendChild(empty);
+      return;
+    }
+
+    entries.forEach(entry => {
+      const li = document.createElement("li");
+      li.className = "audit-item";
+      li.innerHTML = `
+        <time>${formatDate(entry.timestamp)}</time>
+        <strong>${escapeHtml(entry.action)}</strong><br>
+        Usuário: ${escapeHtml(entry.performedBy)}<br>
+        ${entry.licenseKey ? `Licença: ${escapeHtml(entry.licenseKey)}<br>` : ""}
+        ${entry.details ? `<span style="color: var(--muted);">${escapeHtml(entry.details)}</span>` : ""}
+      `;
+      auditList.appendChild(li);
+    });
+  }
+
+  function escapeHtml(value) {
+    return String(value).replace(/[&<>"']/g, char => {
+      const map = { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" };
+      return map[char] ?? char;
+    });
+  }
+
+  function formatDate(value) {
+    if (!value) return "";
+    const date = new Date(value);
+    return date.toLocaleString();
+  }
+
+  async function refreshLicenses() {
+    const licenses = await apiFetch("/admin/api/licenses");
+    currentLicenses = Array.isArray(licenses) ? licenses : [];
+    renderLicenses(currentLicenses);
+  }
+
+  async function refreshAudit() {
+    const entries = await apiFetch("/admin/api/audit?limit=50");
+    renderAudit(Array.isArray(entries) ? entries : []);
+  }
+
+  async function refreshData() {
+    await Promise.all([refreshLicenses(), refreshAudit()]);
+  }
+
+  async function submitLicense(event) {
+    event.preventDefault();
+    const id = licenseIdInput.value;
+    const payload = {
+      key: licenseKeyInput.value.trim(),
+      email: licenseEmailInput.value.trim(),
+      type: licenseTypeSelect.value,
+      status: licenseStatusSelect.value,
+      expiresAt:
+        expirationEnabledCheckbox.checked && licenseExpiresInput.value
+          ? new Date(licenseExpiresInput.value).toISOString()
+          : null,
+      notes: licenseNotesInput.value.trim()
+    };
+
+    try {
+      if (!payload.key || !payload.email) {
+        throw new Error("Informe a chave e o e-mail da licença.");
+      }
+
+      if (id) {
+        await apiFetch(`/admin/api/licenses/${id}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload)
+        });
+        showMessage("Licença atualizada com sucesso.");
+      } else {
+        await apiFetch("/admin/api/licenses", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload)
+        });
+        showMessage("Licença criada com sucesso.");
+      }
+
+      resetLicenseForm();
+      await refreshData();
+    } catch (error) {
+      showMessage(error.message, "error");
+    }
+  }
+
+  async function changeStatus(id, status) {
+    try {
+      await apiFetch(`/admin/api/licenses/${id}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status })
+      });
+      showMessage(`Status alterado para ${status}.`);
+      await refreshLicenses();
+    } catch (error) {
+      showMessage(error.message, "error");
+    }
+  }
+
+  async function deleteLicense(id) {
+    if (!confirm("Confirma a exclusão desta licença?")) {
+      return;
+    }
+
+    try {
+      await apiFetch(`/admin/api/licenses/${id}`, { method: "DELETE" });
+      showMessage("Licença removida.");
+      await refreshData();
+    } catch (error) {
+      showMessage(error.message, "error");
+    }
+  }
+
+  loginForm.addEventListener("submit", login);
+  logoutButton.addEventListener("click", logout);
+  licenseForm.addEventListener("submit", submitLicense);
+  refreshButton.addEventListener("click", refreshData);
+  refreshAuditButton.addEventListener("click", refreshAudit);
+  resetButton.addEventListener("click", resetLicenseForm);
+  expirationEnabledCheckbox.addEventListener("change", () => {
+    licenseExpiresInput.disabled = !expirationEnabledCheckbox.checked;
+    if (!expirationEnabledCheckbox.checked) {
+      licenseExpiresInput.value = "";
+    }
+  });
+
+  licensesBody.addEventListener("click", event => {
+    const button = event.target.closest("button");
+    if (!button) return;
+
+    const container = button.closest(".actions");
+    const id = container?.dataset.id;
+    if (!id) return;
+
+    const license = currentLicenses.find(item => item.id === id);
+    if (!license) return;
+
+    switch (button.dataset.action) {
+      case "edit":
+        fillForm(license);
+        break;
+      case "activate":
+        changeStatus(id, "Active");
+        break;
+      case "deactivate":
+        changeStatus(id, "Inactive");
+        break;
+      case "ban":
+        changeStatus(id, "Banned");
+        break;
+      case "delete":
+        deleteLicense(id);
+        break;
+      default:
+        break;
+    }
+  });
+
+  document.addEventListener("DOMContentLoaded", async () => {
+    populateSelectOptions();
+    resetLicenseForm();
+
+    if (authToken) {
+      try {
+        await refreshData();
+        toggleDashboard(true);
+        showMessage("Sessão restaurada.");
+      } catch (error) {
+        handleUnauthorized();
+      }
+    }
+  });
+})();

--- a/license-manager/LicenseServer/wwwroot/admin/index.html
+++ b/license-manager/LicenseServer/wwwroot/admin/index.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="utf-8">
+  <title>Painel de Licenças - ImperiaMuCMS</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="styles.css">
+  <script src="app.js" defer></script>
+</head>
+<body>
+  <header>
+    <h1>ImperiaMuCMS &mdash; Painel de Licenças</h1>
+    <span id="status-message">Conecte-se para começar.</span>
+    <button id="logout-button" class="logout-button hidden">Sair</button>
+  </header>
+  <main>
+    <section id="login-section" class="card">
+      <h2>Autenticação</h2>
+      <form id="login-form">
+        <div>
+          <label for="login-username">Usuário</label>
+          <input id="login-username" name="username" type="text" autocomplete="username" required placeholder="admin">
+        </div>
+        <div>
+          <label for="login-password">Senha</label>
+          <input id="login-password" name="password" type="password" autocomplete="current-password" required placeholder="admin">
+        </div>
+        <button type="submit" class="primary">Entrar</button>
+      </form>
+      <p style="color: var(--muted); font-size: 0.85rem; margin-top: 12px;">
+        Dica: altere a senha padrão do usuário <strong>admin</strong> após o primeiro acesso.
+      </p>
+    </section>
+
+    <section id="dashboard-section" class="hidden">
+      <div class="grid">
+        <div class="card">
+          <h2 id="form-title">Cadastrar licença</h2>
+          <form id="license-form">
+            <input type="hidden" id="license-id">
+            <div>
+              <label for="license-key">Chave da licença</label>
+              <input id="license-key" type="text" required>
+            </div>
+            <div>
+              <label for="license-email">E-mail do cliente</label>
+              <input id="license-email" type="email" required>
+            </div>
+            <div>
+              <label for="license-type">Tipo</label>
+              <select id="license-type"></select>
+            </div>
+            <div>
+              <label for="license-status">Status</label>
+              <select id="license-status"></select>
+            </div>
+            <div>
+              <label for="license-expires">Expiração</label>
+              <div style="display:flex; gap:8px; align-items:center;">
+                <input id="license-expiration-enabled" type="checkbox" checked>
+                <input id="license-expires" type="datetime-local" style="flex:1;">
+              </div>
+            </div>
+            <div>
+              <label for="license-notes">Observações</label>
+              <textarea id="license-notes" placeholder="Notas internas sobre a licença"></textarea>
+            </div>
+            <div style="display:flex; gap:12px; margin-top:12px;">
+              <button type="submit" class="primary" id="save-button">Salvar</button>
+              <button type="button" class="secondary" id="reset-button">Limpar</button>
+            </div>
+          </form>
+        </div>
+
+        <div class="card" style="overflow-x:auto;">
+          <div style="display:flex; justify-content: space-between; align-items:center;">
+            <h2>Licenças cadastradas</h2>
+            <button type="button" class="secondary" id="refresh-button">Recarregar</button>
+          </div>
+          <table>
+            <thead>
+              <tr>
+                <th>Chave</th>
+                <th>E-mail</th>
+                <th>Tipo</th>
+                <th>Status</th>
+                <th>Criada em</th>
+                <th>Expira em</th>
+                <th>Observações</th>
+                <th>Ações</th>
+              </tr>
+            </thead>
+            <tbody id="licenses-body"></tbody>
+          </table>
+        </div>
+
+        <div class="card">
+          <div style="display:flex; justify-content: space-between; align-items:center;">
+            <h2>Auditoria recente</h2>
+            <button type="button" class="secondary" id="refresh-audit">Atualizar</button>
+          </div>
+          <ul class="audit-list" id="audit-list"></ul>
+        </div>
+      </div>
+    </section>
+  </main>
+</body>
+</html>

--- a/license-manager/LicenseServer/wwwroot/admin/styles.css
+++ b/license-manager/LicenseServer/wwwroot/admin/styles.css
@@ -1,0 +1,262 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f7f8fa;
+  --card-bg: #ffffff;
+  --border: #d6d9e0;
+  --primary: #1d4ed8;
+  --primary-hover: #1e40af;
+  --danger: #dc2626;
+  --success: #16a34a;
+  --muted: #6b7280;
+  --text: #111827;
+}
+
+body {
+  font-family: "Segoe UI", Roboto, sans-serif;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+header {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px 24px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+header h1 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+#status-message {
+  margin-left: auto;
+  font-size: 0.95rem;
+  color: #e2e8f0;
+}
+
+.logout-button {
+  background: transparent;
+  border: 1px solid #94a3b8;
+  color: #e2e8f0;
+  padding: 6px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.logout-button:hover {
+  background: rgba(148, 163, 184, 0.15);
+}
+
+main {
+  flex: 1;
+  padding: 24px;
+  max-width: 1100px;
+  width: 100%;
+  margin: 0 auto;
+  box-sizing: border-box;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 24px;
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+#login-section {
+  max-width: 420px;
+  margin: 60px auto;
+}
+
+#login-section form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input[type="text"],
+input[type="password"],
+input[type="email"],
+input[type="datetime-local"],
+select,
+textarea {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  box-sizing: border-box;
+}
+
+textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+button.primary {
+  background: var(--primary);
+  border: none;
+  color: #fff;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+button.primary:hover {
+  background: var(--primary-hover);
+}
+
+button.secondary {
+  background: transparent;
+  border: 1px solid var(--border);
+  color: var(--muted);
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+
+button.secondary:hover {
+  border-color: var(--muted);
+  color: var(--text);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 24px;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 16px;
+}
+
+table thead {
+  background: #f1f5f9;
+}
+
+th, td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.9rem;
+  vertical-align: top;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.badge {
+  display: inline-block;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge.Active {
+  background: rgba(22, 163, 74, 0.1);
+  color: var(--success);
+}
+
+.badge.Inactive {
+  background: rgba(234, 179, 8, 0.1);
+  color: #b45309;
+}
+
+.badge.Banned {
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--danger);
+}
+
+.actions {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.actions button {
+  font-size: 0.8rem;
+  padding: 6px 10px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: #fff;
+  cursor: pointer;
+}
+
+.actions button:hover {
+  border-color: var(--primary);
+  color: var(--primary);
+}
+
+.actions button.danger {
+  border-color: rgba(220, 38, 38, 0.4);
+  color: var(--danger);
+}
+
+.audit-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  max-height: 360px;
+  overflow-y: auto;
+}
+
+.audit-item {
+  border-left: 3px solid var(--primary);
+  padding-left: 12px;
+  font-size: 0.85rem;
+}
+
+.audit-item time {
+  display: block;
+  font-size: 0.78rem;
+  color: var(--muted);
+  margin-bottom: 2px;
+}
+
+.hidden {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  header {
+    align-items: flex-start;
+  }
+
+  header h1 {
+    font-size: 1.1rem;
+  }
+
+  #status-message {
+    width: 100%;
+    margin-left: 0;
+  }
+}

--- a/license-manager/README.md
+++ b/license-manager/README.md
@@ -11,6 +11,9 @@ Este diretório reúne o gerenciador desktop em Windows Forms e o novo servidor 
 - Definição do tipo de licença compatível com o CMS (`Lite`, `Bronze`, `Silver`, `Gold`, `Premium` e `PremiumPlus`).
 - Definição opcional de data de expiração, com suporte a notas/observações e aos campos extras utilizados pelo CMS.
 - Persistência dos dados em `licenses.json`, utilizando JSON legível e compartilhado com o servidor C#.
+- Autenticação de usuários com auditoria completa das operações realizadas no gerenciador desktop.
+- Backups automáticos versionados do arquivo `licenses.json`, facilitando a restauração de estados anteriores.
+- Painel administrativo web com login e controle remoto das licenças, compartilhando o mesmo repositório de dados.
 
 ## Estrutura do projeto
 
@@ -51,14 +54,24 @@ O arquivo `licenses.json` será carregado automaticamente da pasta de saída. Vo
    ```
 
 4. Os endpoints expostos são equivalentes aos utilizados pelo CMS original:
-   - `GET /apiversion.php` → versão mínima da API (`1`).
-   - `GET /version.php` → versão atual do CMS (`2.0.7`).
-   - `GET /applications/nexus/interface/licenses/?info|check|activate` → rotas de informação, verificação e ativação, retornando respostas criptografadas como o servidor original.
+  - `GET /apiversion.php` → versão mínima da API (`1`).
+  - `GET /version.php` → versão atual do CMS (`2.0.7`).
+  - `GET /applications/nexus/interface/licenses/?info|check|activate` → rotas de informação, verificação e ativação, retornando respostas criptografadas como o servidor original.
 
 As licenças ativas, tipos e campos personalizados são lidos do mesmo `licenses.json` gerenciado pelo aplicativo desktop.
 
+### Painel administrativo web
+
+Com o servidor em execução, acesse `http://localhost:5000/admin` (ou a porta configurada pelo `dotnet run`) para utilizar o painel remoto. Faça login com um usuário cadastrado em `users.json` (por padrão `admin`/`admin`) e:
+
+- Cadastre, edite ou exclua licenças diretamente pelo navegador.
+- Altere rapidamente o status das chaves.
+- Consulte o histórico de auditoria das ações realizadas tanto no desktop quanto via web.
+
+> Recomenda-se alterar a senha padrão do usuário `admin` antes de expor o painel à internet. O arquivo `users.json` aceita múltiplos usuários com senhas criptografadas em SHA-256.
+
 ## Próximos passos sugeridos
 
-- Adicionar autenticação de usuários e trilhas de auditoria no gerenciador.
-- Disponibilizar uma interface web para administrar as licenças remotamente.
-- Automatizar backups/versionamento do arquivo `licenses.json` para facilitar a recuperação.
+- Disponibilizar um fluxo seguro para alteração de senhas diretamente pela interface.
+- Permitir a gestão de múltiplos usuários e perfis de acesso diferenciados.
+- Configurar notificações automáticas (e-mail/webhook) para licenças próximas da expiração.


### PR DESCRIPTION
## Summary
- add shared authentication and audit services with default admin user and automatic license backups
- protect the desktop manager with a login flow, status-aware UI tweaks, and audit logging for mutations
- expand the C# license server with authenticated REST/admin endpoints plus a static web dashboard for remote management
- document the new capabilities and usage in the repository README

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4b5dbe0f08332a4a5f7a8736ff163